### PR TITLE
bugfix Class not found error under symfony 5.2

### DIFF
--- a/src/Environment.php
+++ b/src/Environment.php
@@ -148,7 +148,7 @@ final class Environment
     private function switchContext(Context $context, bool $keepCurrentInStack = false): void
     {
         $command = new BuildContextConfig($this, $context, $this->config);
-        $this->messageBus->dispatch($command::NAME, $command);
+        $this->messageBus->dispatch($command, $command::NAME);
 
         if ($command->getConfig()) {
             $this->config = $command->getConfig();
@@ -161,7 +161,7 @@ final class Environment
         $this->context = $context;
 
         $event = new ContextEntered($this, $context);
-        $this->messageBus->dispatch($event::NAME, $event);
+        $this->messageBus->dispatch($event, $event::NAME);
     }
 
     /**

--- a/src/Listener/HookListener.php
+++ b/src/Listener/HookListener.php
@@ -73,7 +73,7 @@ final class HookListener
     protected function initializeEnvironment(): void
     {
         $event = new InitializeEnvironment($this->environment);
-        $this->eventDispatcher->dispatch($event::NAME, $event);
+        $this->eventDispatcher->dispatch($event, $event::NAME);
     }
 
     /**
@@ -91,6 +91,6 @@ final class HookListener
         $environment->setEnabled($layout->layoutType == 'bootstrap');
 
         $event = new InitializeLayout($environment, $layout, $page);
-        $this->eventDispatcher->dispatch($event::NAME, $event);
+        $this->eventDispatcher->dispatch($event, $event::NAME);
     }
 }

--- a/src/Message/Command/BuildContextConfig.php
+++ b/src/Message/Command/BuildContextConfig.php
@@ -18,7 +18,7 @@ namespace ContaoBootstrap\Core\Message\Command;
 use ContaoBootstrap\Core\Config;
 use ContaoBootstrap\Core\Environment;
 use ContaoBootstrap\Core\Environment\Context;
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\Event;
 
 /**
  * Class BuildContextConfig.

--- a/src/Message/Command/InitializeEnvironment.php
+++ b/src/Message/Command/InitializeEnvironment.php
@@ -16,7 +16,7 @@ declare(strict_types=1);
 namespace ContaoBootstrap\Core\Message\Command;
 
 use ContaoBootstrap\Core\Environment;
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\Event;
 
 /**
  * Class InitializeEnvironmentEvent is emitted then bootstrap environment is initialized.

--- a/src/Message/Command/InitializeLayout.php
+++ b/src/Message/Command/InitializeLayout.php
@@ -18,7 +18,7 @@ namespace ContaoBootstrap\Core\Message\Command;
 use Contao\LayoutModel;
 use Contao\PageModel;
 use ContaoBootstrap\Core\Environment;
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\Event;
 
 /**
  * Class InitializeLayoutEvent is emitted when page layout is initialized.

--- a/src/Message/Event/ContextEntered.php
+++ b/src/Message/Event/ContextEntered.php
@@ -17,7 +17,7 @@ namespace ContaoBootstrap\Core\Message\Event;
 
 use ContaoBootstrap\Core\Environment\Context;
 use ContaoBootstrap\Core\Environment;
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\Event;
 
 /**
  * Class EnterContextEvent.


### PR DESCRIPTION
Extend from Events from Symfony\Contracts\EventDispatcher\Event

